### PR TITLE
hast disk looks like a jail by jls, but it's not a jail

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- add exclusion for hastd
 
 
 0.5 (2016-03-11)

--- a/docs/CONTRIBUTORS.rst
+++ b/docs/CONTRIBUTORS.rst
@@ -1,5 +1,6 @@
 Contributors
 ==============
+Simon RECHER voileux
 
 Steffen Brandemann StbX
 

--- a/src/checkpkgaudit/checkpkgaudit.py
+++ b/src/checkpkgaudit/checkpkgaudit.py
@@ -38,7 +38,8 @@ def _get_jails():
     jails = jls.splitlines()[1:]
     if jails:
         jailargs = [{'jid': jail.split()[0], 'hostname': jail.split()[2]}
-                    for jail in jails]
+                    for jail in jails if not
+                    jail.split()[2].startswith('hastd:') ]
     return jailargs
 
 

--- a/src/checkpkgaudit/checkpkgaudit.py
+++ b/src/checkpkgaudit/checkpkgaudit.py
@@ -39,7 +39,7 @@ def _get_jails():
     if jails:
         jailargs = [{'jid': jail.split()[0], 'hostname': jail.split()[2]}
                     for jail in jails if not
-                    jail.split()[2].startswith('hastd:') ]
+                    jail.split()[2].startswith('hastd:')]
     return jailargs
 
 

--- a/src/checkpkgaudit/tests/test_checkauditpkg.py
+++ b/src/checkpkgaudit/tests/test_checkauditpkg.py
@@ -16,6 +16,7 @@ no_jails = "   JID  IP Address      Hostname        Path"
 
 jails = ("    JID  IP Address      Hostname         Path\n",
          "     50  10.0.0.93       masterdns        /usr/jails/masterdns\n",
+         "     51  -               hastd: disk1 (primary)        /var/empty\n",
          "     52  10.0.0.25       smtp             /usr/jails/smtp\n",
          "     54  10.0.0.53       ns0              /usr/jails/ns0\n",
          "     55  10.0.0.153      ns1              /usr/jails/ns1\n",


### PR DESCRIPTION
If you use hastd, your disks looks like jail by jls. 

root@srv-prdadm-19:~ # jls
   JID  IP Address      Hostname                      Path
   278  -               hastd: disk1 (primary)        /var/empty
   281  -               hastd: disk2 (primary)        /var/empty

so I exclude jail Hostname which start with "hastd:"

BR 
## 

Simon RECHER 
