### PR TITLE
Empty IP JLS

### DIFF
--- a/src/checkpkgaudit/checkpkgaudit.py
+++ b/src/checkpkgaudit/checkpkgaudit.py
@@ -37,9 +37,12 @@ def _get_jails():
     jls = subprocess.check_output('jls')
     jails = jls.splitlines()[1:]
     if jails:
-        jailargs = [{'jid': jail.split()[0], 'hostname': jail.split()[2]}
-                    for jail in jails if not
-                    jail.split()[2].startswith('hastd:')]
+        jailargs = list()
+        for jail in jails:
+            host_idx = 1 if len(jail.split()) == 3 else 2
+            if not jail.split()[host_idx].startswith('hastd:'):
+                jailargs.append({'jid': jail.split()[0],
+                                 'hostname': jail.split()[host_idx]})
     return jailargs
 
 

--- a/src/checkpkgaudit/tests/test_checkauditpkg.py
+++ b/src/checkpkgaudit/tests/test_checkauditpkg.py
@@ -21,7 +21,8 @@ jails = ("    JID  IP Address      Hostname         Path\n",
          "     54  10.0.0.53       ns0              /usr/jails/ns0\n",
          "     55  10.0.0.153      ns1              /usr/jails/ns1\n",
          "     57  10.0.0.80       http             /usr/jails/http\n",
-         "     59  10.0.0.20       supervision      /usr/jails/supervision\n")
+         "     59  10.0.0.20       supervision      /usr/jails/supervision\n",
+         "     61                  formationpy      /usr/jails/formationpy\n")
 
 
 class Test__getjails(unittest.TestCase):
@@ -41,7 +42,8 @@ class Test__getjails(unittest.TestCase):
                {'hostname': 'ns0', 'jid': '54'},
                {'hostname': 'ns1', 'jid': '55'},
                {'hostname': 'http', 'jid': '57'},
-               {'hostname': 'supervision', 'jid': '59'}]
+               {'hostname': 'supervision', 'jid': '59'},
+               {'hostname': 'formationpy', 'jid': '61'}]
         with mock.patch(mocked) as subprocess:
             subprocess.check_output.return_value = ''.join(jails)
             self.assertEqual(meth(), jls)


### PR DESCRIPTION
Adding support for jls command with empty IP Address.
Adding tests coverage too.

fix: #4